### PR TITLE
Add authentication system with daily spending limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,75 +3,75 @@
 # ================================
 
 # =============================================================================
-# SERVER CONFIGURATION
-# =============================================================================
-
-# LLM Provider API Key (Required for production)
-# Get your API key from: https://ai.google.dev/gemini-api/docs/api-key
-GEMINI_API_KEY=your_gemini_api_key_here
-
-# Application Environment
-# Set to "development" to enable Echo provider for testing without API key
-# Leave empty or set to "production" for production deployment
-APP_ENV=development
-
-# TLS Certificate Configuration (Required)
-# Paths to your TLS certificate and private key files
-TLS_CERT_FILE=certs/server.crt
-TLS_KEY_FILE=certs/server.key
-
-# =============================================================================
-# CLIENT CONFIGURATION
-# =============================================================================
-
-# Server hostname for TLS certificate verification
-# Use "localhost" for local development, your domain for production
-SERVER_NAME=localhost
-
-# Path to CA certificate for TLS verification
-# Use your CA certificate path or leave empty for system default
-CA_CERT_FILE=certs/ca.crt
-
-# =============================================================================
 # DEPLOYMENT EXAMPLES
 # =============================================================================
 
-# Local Development Example:
-# GEMINI_API_KEY=                    # Not required in development
-# APP_ENV=development                # Enables Echo provider
-# TLS_CERT_FILE=certs/server.crt     # Self-signed cert
-# TLS_KEY_FILE=certs/server.key      # Self-signed key
-# SERVER_NAME=localhost              # Local development
-# CA_CERT_FILE=certs/ca.crt    # Self-signed CA
+# =============================================
+# LOCAL DEVELOPMENT
+# =============================================
 
-# Production Example:
-# GEMINI_API_KEY=AIzaSy...           # Your actual API key
-# APP_ENV=production                 # Uses Gemini provider only
-# TLS_CERT_FILE=/etc/letsencrypt/live/yourdomain.com/fullchain.pem
-# TLS_KEY_FILE=/etc/letsencrypt/live/yourdomain.com/privkey.pem
-# SERVER_NAME=yourdomain.com         # Your domain
-# CA_CERT_FILE=                      # Use system CA store
-
-# =============================================================================
-# ADDITIONAL SERVER CONFIGURATION
-# =============================================================================
-
-# Server Port
-# Default: 4000
+# SERVER (.env.server):
+API_KEYS=dev-key-1,dev-key-2
+DAILY_CALL_LIMIT=100
+GEMINI_API_KEY=
+APP_ENV=development
+TLS_CERT_FILE=certs/server.crt
+TLS_KEY_FILE=certs/server.key
 PORT=4000
-
-# Session Management
-# How often to check for idle sessions (e.g., 15m, 1h, 30s)
 SESSION_CLEANUP_INTERVAL=15m
-# How long before a session is considered idle (e.g., 2h, 30m)
 SESSION_IDLE_TIMEOUT=2h
-
-# LLM Configuration
-# Gemini model to use
-GEMINI_MODEL=gemini-2.5-flash-lite
-
-# Rate Limiting Configuration
-# Requests per second per IP address
 RATE_LIMIT_RPS=10
-# Burst capacity (requests that can be made immediately)
 RATE_LIMIT_BURST=20
+
+# CLIENT (.env.client):
+API_KEY=dev-key-1
+SERVER_NAME=localhost
+CA_CERT_FILE=certs/ca.crt
+
+# =============================================
+# PRODUCTION
+# =============================================
+
+# SERVER (.env.server):
+API_KEYS=secure-prod-key-1,secure-prod-key-2
+DAILY_CALL_LIMIT=50
+GEMINI_API_KEY=AIzaSy_your_actual_key_here
+APP_ENV=production
+TLS_CERT_FILE=/etc/ssl/certs/server.crt
+TLS_KEY_FILE=/etc/ssl/private/server.key
+PORT=4000
+SESSION_CLEANUP_INTERVAL=15m
+SESSION_IDLE_TIMEOUT=2h
+RATE_LIMIT_RPS=10
+RATE_LIMIT_BURST=20
+
+# CLIENT (.env.client):
+API_KEY=secure-prod-key-1
+SERVER_NAME=api.yourdomain.com
+CA_CERT_FILE=/etc/ssl/certs/ca.crt
+
+# =============================================================================
+# VARIABLE REFERENCE
+# =============================================================================
+
+# AUTHENTICATION
+# API_KEYS - Comma-separated list of valid API keys (server only)
+# API_KEY - Single API key for client authentication (client only)
+# DAILY_CALL_LIMIT - Daily call limit per API key (server only)
+
+# LLM PROVIDER
+# GEMINI_API_KEY - Your Gemini API key from https://ai.google.dev/gemini-api/docs/api-key
+# APP_ENV - "development" (enables Echo provider) or "production" (Gemini only)
+
+# TLS CONFIGURATION
+# TLS_CERT_FILE - Path to server TLS certificate (server only)
+# TLS_KEY_FILE - Path to server TLS private key (server only)
+# SERVER_NAME - Server hostname for TLS verification (client only)
+# CA_CERT_FILE - Path to CA certificate for TLS verification (client only)
+
+# SERVER SETTINGS
+# PORT - Server port (default: 4000)
+# SESSION_CLEANUP_INTERVAL - How often to cleanup idle sessions (e.g. 15m, 1h)
+# SESSION_IDLE_TIMEOUT - How long before session expires (e.g. 2h, 30m)
+# RATE_LIMIT_RPS - Requests per second per API key
+# RATE_LIMIT_BURST - Burst capacity for rate limiting

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This system minimizes data collection while maintaining practical functionality:
 
 **What we track:**
 
-- **IP addresses**: Used for rate limiting
+- **API keys**: Used for authentication and rate limiting per user
 - **Session IDs**: Random identifiers for session request correlation
 - **Bandwidth metrics**: Request/response sizes for system monitoring
 - **Conversation history**: Messages stored in memory with structured metadata
@@ -45,7 +45,7 @@ to maintain conversation context and enable bandwidth optimization
 
 **What we DON'T store:**
 
-- **User identities**: No authentication, accounts, or tracking
+- **User identities**: No persistent accounts or personal data tracking
 - **Persistent chat history**: Sessions are ephemeral - all conversation data is held only in RAM
 - **Message logs**: Server logs contain operational metadata but never actual message content
 
@@ -60,41 +60,68 @@ to maintain conversation context and enable bandwidth optimization
 **Important limitations:**
 
 - Your messages ARE sent to LLM providers with their own data policies
-- IP-based rate limiting means shared networks (offices, cafes) share limits
+- API key-based rate limiting provides per-user limits
 - Conversation history persists in server memory during active sessions for context and optimization
 - All data is ephemeral but may remain in memory until session cleanup occurs
 
-Never send passwords, API keys, or other sensitive information through any chat system.
+Never send passwords, personal API keys, or other sensitive information through any chat system.
 
-## Usage Limits
+## Authentication
 
-To keep this service free for everyone, I have to currently pay for the
-server and LLM calls myself. To prevent abuse, I've set reasonable
-rate limits on the public proxy. These limits should be more than
-enough for normal conversations.
+The server now requires API key authentication for all endpoints except health checks.
+
+### Server Setup
+
+Configure API keys in the server environment:
+
+```bash
+# Server .env
+API_KEYS=key1,key2,key3
+DAILY_CALL_LIMIT=100
+GEMINI_API_KEY=your_gemini_key
+```
+
+### Client Setup
+
+Configure your API key in the client environment:
+
+```bash
+# Client .env  
+API_KEY=key1
+```
 
 ## Quick Start
 
-**Development (no API key needed):**
+**Development (requires API key):**
 
 ```bash
 git clone <repo> && cd microchat.ai
 ./certs/generate-certs.sh
 cp .env.example .env
+# Edit .env to add API_KEYS for server and API_KEY for client
 make dev-server        # Terminal 1
 make dev-client-echo    # Terminal 2
 ```
 
-**Production (requires Gemini API key):**
+**Production (requires API keys + Gemini API key):**
 
-1. Get API key: <https://ai.google.dev/gemini-api/docs/api-key>
-2. Add to `.env`: `GEMINI_API_KEY=your_key_here`  
-3. Run: `make prod-server` and `make prod-client-gemini`
+1. Get Gemini API key: <https://ai.google.dev/gemini-api/docs/api-key>
+2. Generate your authentication API keys
+3. Add to server `.env`: `API_KEYS=key1,key2`, `DAILY_CALL_LIMIT=100`, and `GEMINI_API_KEY=your_key_here`
+4. Add to client `.env`: `API_KEY=key1`
+5. Run: `make prod-server` and `make prod-client-gemini`
 
 ## Environment Variables
 
 Copy `.env.example` to `.env` and configure:
 
+**Server:**
+- `API_KEYS` - Comma-separated list of valid API keys (required)
+- `DAILY_CALL_LIMIT` - Daily call limit per API key (default: 100)
 - `GEMINI_API_KEY` - Your Gemini API key (production only)
-- `APP_ENV=development` - Enables Echo provider (no API key needed)
+- `APP_ENV=development` - Enables Echo provider
+- Certificate paths - Use defaults for development
+
+**Client:**  
+- `API_KEY` - Your API key for server authentication (required)
 - Certificate paths - Use defaults for development

--- a/cmd/client/main_test.go
+++ b/cmd/client/main_test.go
@@ -16,13 +16,15 @@ func generateSessionID() string {
 }
 
 func setupTestApp(t *testing.T) *application {
-	// Set required environment variable for testing
+	// Set required environment variables for testing
 	os.Setenv("CA_CERT_FILE", "certs/ca.crt")
+	os.Setenv("API_KEY", "test-key")
 
 	cfg := config{
 		serverAddr: "localhost:4000",
 		model:      pb.Model_GEMINI_2_5_FLASH_LITE,
 		sessionID:  generateSessionID(),
+		apiKey:     os.Getenv("API_KEY"), // Get API key from environment
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
@@ -43,6 +45,7 @@ func TestHealth(t *testing.T) {
 	app := setupTestApp(t)
 	defer app.conn.Close()
 
+	// Health endpoint doesn't require authentication
 	ctx := context.Background()
 	resp, err := app.grpc.Health(ctx, &pb.HealthRequest{})
 	if err != nil {
@@ -59,7 +62,7 @@ func TestChatMessage(t *testing.T) {
 	defer app.conn.Close()
 
 	testMessage := "Hello, server!"
-	ctx := context.Background()
+	ctx := app.addAuthContext(context.Background())
 
 	req := &pb.ChatRequest{
 		SessionId: app.config.sessionID,
@@ -85,38 +88,49 @@ func TestChatMessage(t *testing.T) {
 
 // Layer 4: Happy path - message index tracking
 func TestMessageIndexTracking(t *testing.T) {
+	// Use different API key for this test to avoid rate limiting
+	os.Setenv("API_KEY", "test-key-2")
 	app := setupTestApp(t)
 	defer app.conn.Close()
 
-	ctx := context.Background()
+	ctx := app.addAuthContext(context.Background())
 	sessionID := app.config.sessionID
 
 	// First message: index=0, expect count=2
-	resp1, _ := app.grpc.Chat(ctx, &pb.ChatRequest{
+	resp1, err := app.grpc.Chat(ctx, &pb.ChatRequest{
 		SessionId:    sessionID,
 		Message:      "First",
 		MessageIndex: 0,
 	})
+	if err != nil {
+		t.Fatalf("First message failed: %v", err)
+	}
 	if resp1.MessageCount != 2 {
 		t.Errorf("First: expected count=2, got %d", resp1.MessageCount)
 	}
 
 	// Second message: index=2, expect count=4
-	resp2, _ := app.grpc.Chat(ctx, &pb.ChatRequest{
+	resp2, err := app.grpc.Chat(ctx, &pb.ChatRequest{
 		SessionId:    sessionID,
 		Message:      "Second",
 		MessageIndex: 2,
 	})
+	if err != nil {
+		t.Fatalf("Second message failed: %v", err)
+	}
 	if resp2.MessageCount != 4 {
 		t.Errorf("Second: expected count=4, got %d", resp2.MessageCount)
 	}
 
 	// Third message: index=4, expect count=6
-	resp3, _ := app.grpc.Chat(ctx, &pb.ChatRequest{
+	resp3, err := app.grpc.Chat(ctx, &pb.ChatRequest{
 		SessionId:    sessionID,
 		Message:      "Third",
 		MessageIndex: 4,
 	})
+	if err != nil {
+		t.Fatalf("Third message failed: %v", err)
+	}
 	if resp3.MessageCount != 6 {
 		t.Errorf("Third: expected count=6, got %d", resp3.MessageCount)
 	}
@@ -124,35 +138,46 @@ func TestMessageIndexTracking(t *testing.T) {
 
 // Edge cases: wrong index and backward compatibility
 func TestDeltaProtocolEdgeCases(t *testing.T) {
+	// Use different API key for this test to avoid rate limiting
+	os.Setenv("API_KEY", "test-key-3")
 	app := setupTestApp(t)
 	defer app.conn.Close()
 
-	ctx := context.Background()
+	ctx := app.addAuthContext(context.Background())
 
 	// Edge case 1: Wrong index (should still work)
 	sessionID1 := generateSessionID()
-	app.grpc.Chat(ctx, &pb.ChatRequest{
+	_, err := app.grpc.Chat(ctx, &pb.ChatRequest{
 		SessionId:    sessionID1,
 		Message:      "First",
 		MessageIndex: 0,
 	})
+	if err != nil {
+		t.Fatalf("First message in wrong index test failed: %v", err)
+	}
 
-	resp, _ := app.grpc.Chat(ctx, &pb.ChatRequest{
+	resp, err := app.grpc.Chat(ctx, &pb.ChatRequest{
 		SessionId:    sessionID1,
 		Message:      "Wrong index",
 		MessageIndex: 10, // Wrong: should be 2
 	})
+	if err != nil {
+		t.Fatalf("Wrong index message failed: %v", err)
+	}
 	if resp.MessageCount != 4 {
 		t.Errorf("Wrong index: expected count=4, got %d", resp.MessageCount)
 	}
 
 	// Edge case 2: No index field (backward compatibility)
 	sessionID2 := generateSessionID()
-	resp2, _ := app.grpc.Chat(ctx, &pb.ChatRequest{
+	resp2, err := app.grpc.Chat(ctx, &pb.ChatRequest{
 		SessionId: sessionID2,
 		Message:   "No index",
 		// MessageIndex omitted
 	})
+	if err != nil {
+		t.Fatalf("No index message failed: %v", err)
+	}
 	if resp2.MessageCount != 2 {
 		t.Errorf("No index: expected count=2, got %d", resp2.MessageCount)
 	}

--- a/cmd/server/interceptor.go
+++ b/cmd/server/interceptor.go
@@ -2,27 +2,92 @@ package main
 
 import (
 	"context"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
-	
+
 	"microchat.ai/cmd/server/ratelimit"
 )
+
+// SpendingLimiter interface for dependency injection
+type SpendingLimiter interface {
+	CanMakeCall(apiKey string) bool
+	RecordCall(apiKey string)
+}
+
+// AuthInterceptor creates a gRPC unary server interceptor for API key authentication
+func AuthInterceptor(apiKeys map[string]bool, spendingTracker SpendingLimiter) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		// Skip auth for Health endpoint only
+		if info.FullMethod == "/chat.ChatService/Health" {
+			return handler(ctx, req)
+		}
+
+		// Require authentication for all other endpoints
+		if len(apiKeys) == 0 {
+			return nil, status.Error(codes.Unauthenticated, "no API keys configured - authentication required")
+		}
+
+		// Extract authorization header from metadata
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "missing metadata")
+		}
+
+		auth := md.Get("authorization")
+		if len(auth) == 0 {
+			return nil, status.Error(codes.Unauthenticated, "missing authorization header")
+		}
+
+		// Check Bearer token format
+		token := auth[0]
+		if !strings.HasPrefix(token, "Bearer ") {
+			return nil, status.Error(codes.Unauthenticated, "invalid authorization format")
+		}
+
+		// Extract and validate API key
+		apiKey := strings.TrimPrefix(token, "Bearer ")
+		if !apiKeys[apiKey] {
+			return nil, status.Error(codes.Unauthenticated, "invalid API key")
+		}
+
+		// Check daily spending limit
+		if !spendingTracker.CanMakeCall(apiKey) {
+			return nil, status.Error(codes.ResourceExhausted, "daily call limit exceeded")
+		}
+
+		// Record this call
+		spendingTracker.RecordCall(apiKey)
+
+		// Add API key to context for rate limiting
+		ctx = context.WithValue(ctx, "api_key", apiKey)
+
+		// Continue with the request
+		return handler(ctx, req)
+	}
+}
 
 // RateLimitInterceptor creates a gRPC unary server interceptor for rate limiting
 func RateLimitInterceptor(ipLimiter *ratelimit.IPLimiter) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		// Extract client IP address
-		clientIP := extractClientIP(ctx)
-		
-		// Check rate limit
-		if !ipLimiter.Allow(clientIP) {
+		// Use API key for rate limiting (auth interceptor runs first)
+		var limitKey string
+		if apiKey := ctx.Value("api_key"); apiKey != nil {
+			limitKey = "api_key:" + apiKey.(string)
+		} else {
+			// This should only happen for Health endpoint
+			limitKey = "ip:" + extractClientIP(ctx)
+		}
+
+		// Check rate limit using the appropriate key
+		if !ipLimiter.Allow(limitKey) {
 			return nil, status.Error(codes.ResourceExhausted, "rate limit exceeded")
 		}
-		
+
 		// Continue with the request
 		return handler(ctx, req)
 	}
@@ -32,15 +97,15 @@ func RateLimitInterceptor(ipLimiter *ratelimit.IPLimiter) grpc.UnaryServerInterc
 func extractClientIP(ctx context.Context) string {
 	// Default fallback IP
 	defaultIP := "unknown"
-	
+
 	// First, try to get the peer information
 	p, ok := peer.FromContext(ctx)
 	if !ok {
 		return defaultIP
 	}
-	
+
 	remoteAddr := p.Addr.String()
-	
+
 	// Check for X-Forwarded-For header in metadata (for proxy situations)
 	var forwardedFor string
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
@@ -48,7 +113,7 @@ func extractClientIP(ctx context.Context) string {
 			forwardedFor = xff[0]
 		}
 	}
-	
+
 	// Use the ratelimit package's IP extraction logic
 	return ratelimit.ExtractIP(remoteAddr, forwardedFor)
 }

--- a/cmd/server/interceptor_test.go
+++ b/cmd/server/interceptor_test.go
@@ -10,28 +10,42 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
-	
+
 	"microchat.ai/cmd/server/ratelimit"
 )
+
+// MockSpendingTracker for testing
+type MockSpendingTracker struct {
+	canMakeCall  bool
+	callRecorded bool
+}
+
+func (m *MockSpendingTracker) CanMakeCall(apiKey string) bool {
+	return m.canMakeCall
+}
+
+func (m *MockSpendingTracker) RecordCall(apiKey string) {
+	m.callRecorded = true
+}
 
 func TestRateLimitInterceptor(t *testing.T) {
 	// Create a limiter with very restrictive limits for testing
 	ipLimiter := ratelimit.NewIPLimiter(1, 1) // 1 RPS, burst of 1
 	defer ipLimiter.Stop()
-	
+
 	interceptor := RateLimitInterceptor(ipLimiter)
-	
+
 	// Mock handler that just returns success
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return "success", nil
 	}
-	
+
 	// Create a context with peer information
 	addr, _ := net.ResolveTCPAddr("tcp", "192.168.1.1:54321")
 	ctx := peer.NewContext(context.Background(), &peer.Peer{
 		Addr: addr,
 	})
-	
+
 	// First request should succeed
 	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test"}, handler)
 	if err != nil {
@@ -40,13 +54,13 @@ func TestRateLimitInterceptor(t *testing.T) {
 	if resp != "success" {
 		t.Errorf("expected success response, got: %v", resp)
 	}
-	
+
 	// Second request should be rate limited
 	resp, err = interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test"}, handler)
 	if err == nil {
 		t.Error("expected second request to be rate limited")
 	}
-	
+
 	// Check that it's the correct error code
 	st, ok := status.FromError(err)
 	if !ok {
@@ -63,37 +77,37 @@ func TestRateLimitInterceptor(t *testing.T) {
 func TestRateLimitInterceptorDifferentIPs(t *testing.T) {
 	ipLimiter := ratelimit.NewIPLimiter(1, 1) // 1 RPS, burst of 1
 	defer ipLimiter.Stop()
-	
+
 	interceptor := RateLimitInterceptor(ipLimiter)
-	
+
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return "success", nil
 	}
-	
+
 	// Create contexts for different IPs
 	addr1, _ := net.ResolveTCPAddr("tcp", "192.168.1.1:54321")
 	ctx1 := peer.NewContext(context.Background(), &peer.Peer{Addr: addr1})
-	
+
 	addr2, _ := net.ResolveTCPAddr("tcp", "192.168.1.2:54321")
 	ctx2 := peer.NewContext(context.Background(), &peer.Peer{Addr: addr2})
-	
+
 	// Both IPs should be able to make one request
 	_, err1 := interceptor(ctx1, nil, &grpc.UnaryServerInfo{FullMethod: "/test"}, handler)
 	if err1 != nil {
 		t.Errorf("expected request from IP1 to succeed, got: %v", err1)
 	}
-	
+
 	_, err2 := interceptor(ctx2, nil, &grpc.UnaryServerInfo{FullMethod: "/test"}, handler)
 	if err2 != nil {
 		t.Errorf("expected request from IP2 to succeed, got: %v", err2)
 	}
-	
+
 	// Second requests from both should be rate limited
 	_, err1 = interceptor(ctx1, nil, &grpc.UnaryServerInfo{FullMethod: "/test"}, handler)
 	if err1 == nil {
 		t.Error("expected second request from IP1 to be rate limited")
 	}
-	
+
 	_, err2 = interceptor(ctx2, nil, &grpc.UnaryServerInfo{FullMethod: "/test"}, handler)
 	if err2 == nil {
 		t.Error("expected second request from IP2 to be rate limited")
@@ -102,9 +116,9 @@ func TestRateLimitInterceptorDifferentIPs(t *testing.T) {
 
 func TestExtractClientIP(t *testing.T) {
 	tests := []struct {
-		name         string
-		setupCtx     func() context.Context
-		expectedIP   string
+		name       string
+		setupCtx   func() context.Context
+		expectedIP string
 	}{
 		{
 			name: "basic peer IP",
@@ -150,7 +164,7 @@ func TestExtractClientIP(t *testing.T) {
 			expectedIP: "2001:db8::1",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := tt.setupCtx()
@@ -165,37 +179,314 @@ func TestExtractClientIP(t *testing.T) {
 func TestRateLimitInterceptorWithForwardedFor(t *testing.T) {
 	ipLimiter := ratelimit.NewIPLimiter(1, 1) // 1 RPS, burst of 1
 	defer ipLimiter.Stop()
-	
+
 	interceptor := RateLimitInterceptor(ipLimiter)
-	
+
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return "success", nil
 	}
-	
+
 	// Create context with proxy IP but real client IP in X-Forwarded-For
 	addr, _ := net.ResolveTCPAddr("tcp", "10.0.0.1:54321") // Proxy IP
 	ctx := peer.NewContext(context.Background(), &peer.Peer{Addr: addr})
 	md := metadata.Pairs("x-forwarded-for", "203.0.113.1") // Real client IP
 	ctx = metadata.NewIncomingContext(ctx, md)
-	
+
 	// First request should succeed
 	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test"}, handler)
 	if err != nil {
 		t.Errorf("expected first request to succeed, got: %v", err)
 	}
-	
+
 	// Second request should be rate limited based on the X-Forwarded-For IP
 	_, err = interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/test"}, handler)
 	if err == nil {
 		t.Error("expected second request to be rate limited")
 	}
-	
+
 	// Request from different forwarded IP should succeed
 	md2 := metadata.Pairs("x-forwarded-for", "203.0.113.2")
 	ctx2 := metadata.NewIncomingContext(peer.NewContext(context.Background(), &peer.Peer{Addr: addr}), md2)
-	
+
 	_, err = interceptor(ctx2, nil, &grpc.UnaryServerInfo{FullMethod: "/test"}, handler)
 	if err != nil {
 		t.Errorf("expected request from different forwarded IP to succeed, got: %v", err)
+	}
+}
+
+// Authentication Tests
+
+func TestAuthInterceptor_HealthEndpoint(t *testing.T) {
+	// Health endpoint should bypass all auth checks
+	apiKeys := map[string]bool{"test-key": true}
+	mockTracker := &MockSpendingTracker{canMakeCall: true}
+	interceptor := AuthInterceptor(apiKeys, mockTracker)
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "success", nil
+	}
+
+	// No auth header - should still work for health endpoint
+	ctx := context.Background()
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/chat.ChatService/Health"}, handler)
+
+	if err != nil {
+		t.Errorf("expected health endpoint to work without auth, got: %v", err)
+	}
+	if resp != "success" {
+		t.Errorf("expected success response, got: %v", resp)
+	}
+}
+
+func TestAuthInterceptor_MissingAuth(t *testing.T) {
+	apiKeys := map[string]bool{"test-key": true}
+	mockTracker := &MockSpendingTracker{canMakeCall: true}
+	interceptor := AuthInterceptor(apiKeys, mockTracker)
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "success", nil
+	}
+
+	// No metadata at all
+	ctx := context.Background()
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/chat.ChatService/Chat"}, handler)
+
+	if err == nil {
+		t.Error("expected auth failure for missing metadata")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Error("expected gRPC status error")
+	}
+	if st.Code() != codes.Unauthenticated {
+		t.Errorf("expected Unauthenticated code, got: %v", st.Code())
+	}
+	if st.Message() != "missing metadata" {
+		t.Errorf("expected missing metadata message, got: %v", st.Message())
+	}
+}
+
+func TestAuthInterceptor_MissingAuthHeader(t *testing.T) {
+	apiKeys := map[string]bool{"test-key": true}
+	mockTracker := &MockSpendingTracker{canMakeCall: true}
+	interceptor := AuthInterceptor(apiKeys, mockTracker)
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "success", nil
+	}
+
+	// Metadata without authorization header
+	md := metadata.Pairs("other-header", "value")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/chat.ChatService/Chat"}, handler)
+
+	if err == nil {
+		t.Error("expected auth failure for missing authorization header")
+	}
+
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Unauthenticated {
+		t.Errorf("expected Unauthenticated code, got: %v", st.Code())
+	}
+	if st.Message() != "missing authorization header" {
+		t.Errorf("expected missing authorization header message, got: %v", st.Message())
+	}
+}
+
+func TestAuthInterceptor_InvalidAuthFormat(t *testing.T) {
+	apiKeys := map[string]bool{"test-key": true}
+	mockTracker := &MockSpendingTracker{canMakeCall: true}
+	interceptor := AuthInterceptor(apiKeys, mockTracker)
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "success", nil
+	}
+
+	// Invalid auth format (not Bearer)
+	md := metadata.Pairs("authorization", "Basic dXNlcjpwYXNz")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/chat.ChatService/Chat"}, handler)
+
+	if err == nil {
+		t.Error("expected auth failure for invalid format")
+	}
+
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Unauthenticated {
+		t.Errorf("expected Unauthenticated code, got: %v", st.Code())
+	}
+	if st.Message() != "invalid authorization format" {
+		t.Errorf("expected invalid authorization format message, got: %v", st.Message())
+	}
+}
+
+func TestAuthInterceptor_InvalidAPIKey(t *testing.T) {
+	apiKeys := map[string]bool{"valid-key": true}
+	mockTracker := &MockSpendingTracker{canMakeCall: true}
+	interceptor := AuthInterceptor(apiKeys, mockTracker)
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "success", nil
+	}
+
+	// Invalid API key
+	md := metadata.Pairs("authorization", "Bearer invalid-key")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/chat.ChatService/Chat"}, handler)
+
+	if err == nil {
+		t.Error("expected auth failure for invalid API key")
+	}
+
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Unauthenticated {
+		t.Errorf("expected Unauthenticated code, got: %v", st.Code())
+	}
+	if st.Message() != "invalid API key" {
+		t.Errorf("expected invalid API key message, got: %v", st.Message())
+	}
+}
+
+func TestAuthInterceptor_DailyLimitExceeded(t *testing.T) {
+	apiKeys := map[string]bool{"test-key": true}
+	mockTracker := &MockSpendingTracker{canMakeCall: false} // Over limit
+	interceptor := AuthInterceptor(apiKeys, mockTracker)
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "success", nil
+	}
+
+	// Valid API key but over spending limit
+	md := metadata.Pairs("authorization", "Bearer test-key")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/chat.ChatService/Chat"}, handler)
+
+	if err == nil {
+		t.Error("expected auth failure for daily limit exceeded")
+	}
+
+	st, _ := status.FromError(err)
+	if st.Code() != codes.ResourceExhausted {
+		t.Errorf("expected ResourceExhausted code, got: %v", st.Code())
+	}
+	if st.Message() != "daily call limit exceeded" {
+		t.Errorf("expected daily call limit exceeded message, got: %v", st.Message())
+	}
+}
+
+func TestAuthInterceptor_Success(t *testing.T) {
+	apiKeys := map[string]bool{"test-key": true}
+	mockTracker := &MockSpendingTracker{canMakeCall: true}
+	interceptor := AuthInterceptor(apiKeys, mockTracker)
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		// Check that API key was added to context
+		if apiKey := ctx.Value("api_key"); apiKey != "test-key" {
+			t.Errorf("expected api_key in context to be 'test-key', got: %v", apiKey)
+		}
+		return "success", nil
+	}
+
+	// Valid API key and under limit
+	md := metadata.Pairs("authorization", "Bearer test-key")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	resp, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/chat.ChatService/Chat"}, handler)
+
+	if err != nil {
+		t.Errorf("expected successful auth, got: %v", err)
+	}
+	if resp != "success" {
+		t.Errorf("expected success response, got: %v", resp)
+	}
+	if !mockTracker.callRecorded {
+		t.Error("expected call to be recorded in spending tracker")
+	}
+}
+
+func TestAuthInterceptor_NoAPIKeys(t *testing.T) {
+	apiKeys := map[string]bool{} // No keys configured
+	mockTracker := &MockSpendingTracker{canMakeCall: true}
+	interceptor := AuthInterceptor(apiKeys, mockTracker)
+
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "success", nil
+	}
+
+	// No auth header when no API keys configured
+	ctx := context.Background()
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{FullMethod: "/chat.ChatService/Chat"}, handler)
+
+	if err == nil {
+		t.Error("expected auth failure when no API keys configured")
+	}
+
+	st, _ := status.FromError(err)
+	if st.Code() != codes.Unauthenticated {
+		t.Errorf("expected Unauthenticated code, got: %v", st.Code())
+	}
+	if st.Message() != "no API keys configured - authentication required" {
+		t.Errorf("expected no API keys configured message, got: %v", st.Message())
+	}
+}
+
+// Spending Tracker Tests
+
+func TestSpendingTracker_NewKey(t *testing.T) {
+	tracker := NewSpendingTracker(5) // 5 calls per day
+
+	// New key should be able to make calls
+	if !tracker.CanMakeCall("new-key") {
+		t.Error("expected new key to be able to make calls")
+	}
+
+	// Record a call
+	tracker.RecordCall("new-key")
+
+	// Should still be able to make calls (1/5 used)
+	if !tracker.CanMakeCall("new-key") {
+		t.Error("expected key to still be under limit")
+	}
+}
+
+func TestSpendingTracker_HitLimit(t *testing.T) {
+	tracker := NewSpendingTracker(2) // 2 calls per day
+	apiKey := "test-key"
+
+	// Should be able to make calls initially
+	if !tracker.CanMakeCall(apiKey) {
+		t.Error("expected to be under limit initially")
+	}
+
+	// Use up the daily limit
+	tracker.RecordCall(apiKey) // Call 1
+	if !tracker.CanMakeCall(apiKey) {
+		t.Error("expected to be under limit after 1 call")
+	}
+
+	tracker.RecordCall(apiKey) // Call 2 - now at limit
+	if tracker.CanMakeCall(apiKey) {
+		t.Error("expected to be at limit after 2 calls")
+	}
+}
+
+func TestSpendingTracker_DifferentKeys(t *testing.T) {
+	tracker := NewSpendingTracker(1) // 1 call per day
+
+	// Each key should have independent limits
+	tracker.RecordCall("key1")
+	tracker.RecordCall("key2")
+
+	// Both keys should now be at their limit
+	if tracker.CanMakeCall("key1") {
+		t.Error("expected key1 to be at limit")
+	}
+	if tracker.CanMakeCall("key2") {
+		t.Error("expected key2 to be at limit")
+	}
+
+	// New key should still work
+	if !tracker.CanMakeCall("key3") {
+		t.Error("expected key3 to be under limit")
 	}
 }

--- a/cmd/server/ratelimit/limiter.go
+++ b/cmd/server/ratelimit/limiter.go
@@ -30,16 +30,16 @@ type limitEntry struct {
 func NewIPLimiter(rps rate.Limit, burst int) *IPLimiter {
 	il := &IPLimiter{
 		limiters:        make(map[string]*limitEntry),
-		rps:            rps,
-		burst:          burst,
+		rps:             rps,
+		burst:           burst,
 		cleanupInterval: 10 * time.Minute, // Check every 10 minutes
-		expiry:         24 * time.Hour,    // Remove entries not seen for 24 hours
-		stopCleanup:    make(chan bool),
+		expiry:          24 * time.Hour,   // Remove entries not seen for 24 hours
+		stopCleanup:     make(chan bool),
 	}
-	
+
 	// Start cleanup goroutine
 	go il.cleanupWorker()
-	
+
 	return il
 }
 
@@ -47,7 +47,7 @@ func NewIPLimiter(rps rate.Limit, burst int) *IPLimiter {
 func (il *IPLimiter) Allow(ip string) bool {
 	il.mu.Lock()
 	defer il.mu.Unlock()
-	
+
 	entry, exists := il.limiters[ip]
 	if !exists {
 		// Create new limiter for this IP
@@ -60,7 +60,7 @@ func (il *IPLimiter) Allow(ip string) bool {
 		// Update last seen time
 		entry.lastSeen = time.Now()
 	}
-	
+
 	return entry.limiter.Allow()
 }
 
@@ -68,7 +68,7 @@ func (il *IPLimiter) Allow(ip string) bool {
 func (il *IPLimiter) cleanupWorker() {
 	ticker := time.NewTicker(il.cleanupInterval)
 	defer ticker.Stop()
-	
+
 	for {
 		select {
 		case <-ticker.C:
@@ -83,7 +83,7 @@ func (il *IPLimiter) cleanupWorker() {
 func (il *IPLimiter) cleanup() {
 	il.mu.Lock()
 	defer il.mu.Unlock()
-	
+
 	now := time.Now()
 	for ip, entry := range il.limiters {
 		if now.Sub(entry.lastSeen) > il.expiry {
@@ -118,7 +118,7 @@ func ExtractIP(remoteAddr string, forwardedFor string) string {
 			}
 		}
 	}
-	
+
 	// Fall back to remote address
 	host, _, err := net.SplitHostPort(remoteAddr)
 	if err != nil {

--- a/cmd/server/ratelimit/limiter_test.go
+++ b/cmd/server/ratelimit/limiter_test.go
@@ -8,7 +8,7 @@ import (
 func TestNewIPLimiter(t *testing.T) {
 	limiter := NewIPLimiter(10, 20)
 	defer limiter.Stop()
-	
+
 	if limiter.rps != 10 {
 		t.Errorf("expected RPS to be 10, got %v", limiter.rps)
 	}
@@ -24,31 +24,31 @@ func TestIPLimiterAllow(t *testing.T) {
 	// Create a limiter with 2 RPS, burst of 3
 	limiter := NewIPLimiter(2, 3)
 	defer limiter.Stop()
-	
+
 	ip := "192.168.1.1"
-	
+
 	// Should allow first 3 requests (burst capacity)
 	for i := 0; i < 3; i++ {
 		if !limiter.Allow(ip) {
 			t.Errorf("expected request %d to be allowed", i+1)
 		}
 	}
-	
+
 	// 4th request should be denied (burst capacity exhausted)
 	if limiter.Allow(ip) {
 		t.Error("expected 4th request to be denied")
 	}
-	
+
 	// Wait for tokens to replenish (at 2 RPS, wait 1 second for 2 tokens)
 	time.Sleep(1100 * time.Millisecond)
-	
+
 	// Should allow 2 more requests
 	for i := 0; i < 2; i++ {
 		if !limiter.Allow(ip) {
 			t.Errorf("expected request after wait to be allowed")
 		}
 	}
-	
+
 	// Next request should be denied
 	if limiter.Allow(ip) {
 		t.Error("expected request after burst to be denied")
@@ -58,10 +58,10 @@ func TestIPLimiterAllow(t *testing.T) {
 func TestIPLimiterMultipleIPs(t *testing.T) {
 	limiter := NewIPLimiter(1, 2)
 	defer limiter.Stop()
-	
+
 	ip1 := "192.168.1.1"
 	ip2 := "192.168.1.2"
-	
+
 	// Each IP should have its own limit
 	if !limiter.Allow(ip1) {
 		t.Error("expected first request from IP1 to be allowed")
@@ -69,7 +69,7 @@ func TestIPLimiterMultipleIPs(t *testing.T) {
 	if !limiter.Allow(ip2) {
 		t.Error("expected first request from IP2 to be allowed")
 	}
-	
+
 	// Second burst request for each IP
 	if !limiter.Allow(ip1) {
 		t.Error("expected second request from IP1 to be allowed")
@@ -77,7 +77,7 @@ func TestIPLimiterMultipleIPs(t *testing.T) {
 	if !limiter.Allow(ip2) {
 		t.Error("expected second request from IP2 to be allowed")
 	}
-	
+
 	// Third request should be denied for both
 	if limiter.Allow(ip1) {
 		t.Error("expected third request from IP1 to be denied")
@@ -85,7 +85,7 @@ func TestIPLimiterMultipleIPs(t *testing.T) {
 	if limiter.Allow(ip2) {
 		t.Error("expected third request from IP2 to be denied")
 	}
-	
+
 	// Check that we have 2 active limiters
 	if count := limiter.GetActiveCount(); count != 2 {
 		t.Errorf("expected 2 active limiters, got %d", count)
@@ -97,22 +97,22 @@ func TestIPLimiterCleanup(t *testing.T) {
 	// Set a very short expiry for testing
 	limiter.expiry = 100 * time.Millisecond
 	defer limiter.Stop()
-	
+
 	ip := "192.168.1.1"
-	
+
 	// Make a request to create a limiter entry
 	limiter.Allow(ip)
-	
+
 	if count := limiter.GetActiveCount(); count != 1 {
 		t.Errorf("expected 1 active limiter, got %d", count)
 	}
-	
+
 	// Wait for expiry
 	time.Sleep(200 * time.Millisecond)
-	
+
 	// Trigger cleanup manually
 	limiter.cleanup()
-	
+
 	if count := limiter.GetActiveCount(); count != 0 {
 		t.Errorf("expected 0 active limiters after cleanup, got %d", count)
 	}
@@ -168,12 +168,12 @@ func TestExtractIP(t *testing.T) {
 			expected:     "2001:db8::1",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := ExtractIP(tt.remoteAddr, tt.forwardedFor)
 			if result != tt.expected {
-				t.Errorf("ExtractIP(%q, %q) = %q, want %q", 
+				t.Errorf("ExtractIP(%q, %q) = %q, want %q",
 					tt.remoteAddr, tt.forwardedFor, result, tt.expected)
 			}
 		})
@@ -183,9 +183,9 @@ func TestExtractIP(t *testing.T) {
 func TestIPLimiterConcurrency(t *testing.T) {
 	limiter := NewIPLimiter(100, 200) // High limits for concurrency test
 	defer limiter.Stop()
-	
+
 	ip := "192.168.1.1"
-	
+
 	// Run multiple goroutines concurrently
 	results := make(chan bool, 10)
 	for i := 0; i < 10; i++ {
@@ -193,7 +193,7 @@ func TestIPLimiterConcurrency(t *testing.T) {
 			results <- limiter.Allow(ip)
 		}()
 	}
-	
+
 	// Collect results
 	allowed := 0
 	for i := 0; i < 10; i++ {
@@ -201,12 +201,12 @@ func TestIPLimiterConcurrency(t *testing.T) {
 			allowed++
 		}
 	}
-	
+
 	// All requests should be allowed with high limits
 	if allowed != 10 {
 		t.Errorf("expected all 10 concurrent requests to be allowed, got %d", allowed)
 	}
-	
+
 	// Should have exactly one limiter entry
 	if count := limiter.GetActiveCount(); count != 1 {
 		t.Errorf("expected 1 active limiter after concurrent access, got %d", count)
@@ -215,17 +215,17 @@ func TestIPLimiterConcurrency(t *testing.T) {
 
 func TestIPLimiterStop(t *testing.T) {
 	limiter := NewIPLimiter(10, 20)
-	
+
 	// Make a request to ensure cleanup worker is running
 	limiter.Allow("192.168.1.1")
-	
+
 	// Stop should not hang
 	done := make(chan bool)
 	go func() {
 		limiter.Stop()
 		close(done)
 	}()
-	
+
 	// Wait for stop with timeout
 	select {
 	case <-done:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.6
 require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
+	golang.org/x/time v0.12.0
 	google.golang.org/genai v1.22.0
 	google.golang.org/grpc v1.75.0
 	google.golang.org/protobuf v1.36.8
@@ -24,6 +25,5 @@ require (
 	golang.org/x/net v0.41.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.26.0 // indirect
-	golang.org/x/time v0.12.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250707201910-8d1bb00bc6a7 // indirect
 )


### PR DESCRIPTION
## Summary
- Implements bearer token authentication via gRPC metadata interceptors
- Adds API key validation with configurable keys via `API_KEYS` environment variable
- Implements daily call limits per API key using `SpendingTracker` with configurable `DAILY_CALL_LIMIT`
- Switches rate limiting from per-IP to per-API-key for better resource control
- Fixes .env path resolution to check current working directory first, then fallback

## Test plan
- [x] Verify authentication works with valid API keys
- [x] Verify authentication rejects invalid/missing API keys
- [x] Test daily spending limits enforcement
- [x] Test rate limiting per API key
- [x] Verify .env file loading from different directories
- [x] Run existing test suite to ensure no regressions