### PR TITLE
Fix client TLS configuration for production deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@
 # LOCAL DEVELOPMENT
 # =============================================
 
-# SERVER (.env.server):
+# SERVER (.env):
 API_KEYS=dev-key-1,dev-key-2
 DAILY_CALL_LIMIT=100
 GEMINI_API_KEY=
@@ -26,8 +26,8 @@ MAX_SESSION_SIZE_KB=100
 RATE_LIMIT_RPS=10
 RATE_LIMIT_BURST=20
 
-# CLIENT (.env.client):
-API_KEY=dev-key-1
+# CLIENT (.env):
+MICROCHAT_API_KEY=dev-key-1
 SERVER_NAME=localhost
 CA_CERT_FILE=certs/ca.crt
 
@@ -35,7 +35,7 @@ CA_CERT_FILE=certs/ca.crt
 # PRODUCTION
 # =============================================
 
-# SERVER (.env.server):
+# SERVER (.env):
 API_KEYS=secure-prod-key-1,secure-prod-key-2
 DAILY_CALL_LIMIT=50
 GEMINI_API_KEY=AIzaSy_your_actual_key_here
@@ -51,8 +51,8 @@ MAX_SESSION_SIZE_KB=100
 RATE_LIMIT_RPS=10
 RATE_LIMIT_BURST=20
 
-# CLIENT (.env.client):
-API_KEY=secure-prod-key-1
+# CLIENT (.env):
+MICROCHAT_API_KEY=secure-prod-key-1
 SERVER_NAME=api.yourdomain.com
 CA_CERT_FILE=/etc/ssl/certs/ca.crt
 
@@ -62,7 +62,7 @@ CA_CERT_FILE=/etc/ssl/certs/ca.crt
 
 # AUTHENTICATION
 # API_KEYS - Comma-separated list of valid API keys (server only)
-# API_KEY - Single API key for client authentication (client only)
+# MICROCHAT_API_KEY - Single API key for client authentication (client only)
 # DAILY_CALL_LIMIT - Daily call limit per API key (server only)
 
 # LLM PROVIDER

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,30 @@
-# Naming Convention: <env>-<component>-<model>-<options>
-# Examples: dev-server, prod-server, dev-client-echo-metrics, prod-client-gemini-detail
+# Development-only Makefile for local testing
 
 # =============================================================================
-# SERVER TARGETS
+# SERVERS
 # =============================================================================
 
-# Development server (allows Echo provider)
-dev-server:
+server:
 	cd cmd/server && APP_ENV=development TLS_CERT_FILE=../../certs/server.crt TLS_KEY_FILE=../../certs/server.key go run .
 
-# Production server (no Echo provider access)
-prod-server:
-	cd cmd/server && APP_ENV=production TLS_CERT_FILE=../../certs/server.crt TLS_KEY_FILE=../../certs/server.key go run .
-
 # =============================================================================
-# CLIENT TARGETS
+# CLIENTS  
 # =============================================================================
 
-# Development clients with Echo model
-dev-client-echo:
+client-echo:
 	cd cmd/client && go run . -model=echo
 
-dev-client-echo-metrics:
-	cd cmd/client && go run . -model=echo --metrics
-
-dev-client-echo-detail:
-	cd cmd/client && go run . -model=echo --metrics-detail
-
-# Production clients with Gemini model
-prod-client-gemini:
+client-gemini:
 	cd cmd/client && go run . -model=gemini
 
-prod-client-gemini-metrics:
-	cd cmd/client && go run . -model=gemini --metrics
+client-gemini-metrics:
+	cd cmd/client && go run . -model=gemini -metrics
 
-prod-client-gemini-detail:
-	cd cmd/client && go run . -model=gemini --metrics-detail
+client-gemini-detail:
+	cd cmd/client && go run . -model=gemini -metrics-detail
 
 # =============================================================================
-# DEVELOPMENT TOOLS
+# TOOLS
 # =============================================================================
 
 proto:
@@ -57,6 +43,7 @@ audit:
 	go vet ./...
 	go mod tidy
 	go mod verify
+	govulncheck ./...
 	go test ./...
 	go build ./...
 
@@ -64,7 +51,6 @@ audit:
 # PHONY TARGETS
 # =============================================================================
 
-.PHONY: dev-server prod-server client \
-        dev-client-echo dev-client-echo-metrics dev-client-echo-detail \
-        prod-client-gemini prod-client-gemini-metrics prod-client-gemini-detail \
+.PHONY: server \
+        client-echo client-gemini client-gemini-metrics client-gemini-detail \
         proto test build audit

--- a/README.md
+++ b/README.md
@@ -2,126 +2,82 @@
 
 **Bandwidth compressed chats with a SOTA LLM over the wire.**
 
-I am frequently on a plane with a 30MB in-flight Wi-Fi plan, and I want to have a
-conversation with a SOTA LLM like Claude or Gemini.
+I am frequently on a plane with a 30MB in-flight Wi-Fi plan, and I want to 
+have a conversation with a SOTA LLM like Claude or Gemini.
 
-The problem is that standard chat clients burn through data. Their requests are
-verbose and the text isn't compressed, so my 30MB data cap disappears in
-minutes.
+The problem is that standard chat clients burn through data. Their requests 
+are verbose and the text isn't compressed, so my 30MB data cap disappears 
+in minutes.
 
 So how can I have a long, useful conversation with a SOTA LLM without
 running out of data?
 
-I built `microchat.ai`, a system that uses a compression proxy to solve this
-problem. It works using two parts:
+I built `microchat.ai`, a system that uses a compression proxy to solve 
+this problem. It works using two parts:
 
 1. **A terminal client (`cmd/client/`):** A CLI application that:
-   - Connects over the wire via gRPC to a proxy server with gzip compression
+   - Connects via gRPC to a proxy server with gzip compression
    - Uses Protocol Buffers for compact binary encoding
-   - Tracks real-time bandwidth usage at both payload and wire levels
-   - Shows you exactly how many bytes you're sending/receiving
+   - Tracks real-time bandwidth usage at payload and wire levels
+   - Shows exactly how many bytes you're sending/receiving
 
 2. **A proxy server (`cmd/server/`):** A gRPC server that:
    - Receives your compressed messages over TLS-secured gRPC
    - Forwards them to LLM APIs (Claude, GPT-4, Gemini)
    - Compresses the LLM response before sending back
-   - Maintains ephemeral sessions without logging conversations
+   - Maintains ephemeral sessions without logging
 
-This architecture strips out all the protocol overhead and focuses on
-transferring only the essential, compressed data, letting you chat for hours,
-not minutes.
+This architecture strips out protocol overhead and focuses on transferring 
+only essential, compressed data, letting you chat for hours, not minutes.
 
 ## Privacy & Data Handling
 
-This system minimizes data collection while maintaining practical functionality:
+- **Ephemeral sessions**: No persistent storage - all data held in RAM only
+- **No user tracking**: Random session IDs, no accounts or personal data  
+- **TLS encrypted**: All client-server communication is encrypted
+- **Messages forwarded**: Your messages are sent to LLM providers
 
-**What we track:**
+Never send passwords or sensitive information through any chat system.
 
-- **API keys**: Used for authentication and rate limiting per user
-- **Session IDs**: Random identifiers for session request correlation
-- **Bandwidth metrics**: Request/response sizes for system monitoring
-- **Conversation history**: Messages stored in memory with structured metadata
-to maintain conversation context and enable bandwidth optimization
+## Client Setup
 
-**What we DON'T store:**
-
-- **User identities**: No persistent accounts or personal data tracking
-- **Persistent chat history**: Sessions are ephemeral - all conversation data is held only in RAM
-- **Message logs**: Server logs contain operational metadata but never actual message content
-
-**Technical details:**
-
-- Sessions use randomly generated IDs stored in memory only
-- No database - all conversation state is held in RAM and cleared when sessions end
-- Structured message storage enables delta protocol optimization (sending only new messages)
-- TLS encryption for all client-server communication
-- Automatic cleanup removes idle sessions to prevent memory buildup
-
-**Important limitations:**
-
-- Your messages ARE sent to LLM providers with their own data policies
-- API key-based rate limiting provides per-user limits
-- Conversation history persists in server memory during active sessions for context and optimization
-- All data is ephemeral but may remain in memory until session cleanup occurs
-
-Never send passwords, personal API keys, or other sensitive information through any chat system.
-
-## Authentication
-
-The server now requires API key authentication for all endpoints except health checks.
-
-### Server Setup
-
-Configure API keys in the server environment:
+**Build and connect to production server:**
 
 ```bash
-# Server .env
+# Build client binary (from project root)
+go build -o microchat-client cmd/client/*.go
+
+# Get API key from server admin, then connect
+export MICROCHAT_API_KEY=your_api_key
+./microchat-client -addr="microchat.ai:443"
+
+# With metrics tracking:
+./microchat-client -addr="microchat.ai:443" -metrics
+
+# With detailed metrics:  
+./microchat-client -addr="microchat.ai:443" -metrics-detail
+```
+
+The client automatically detects production domains and uses system certs.
+
+## Server Setup  
+
+**Deploy production server:**
+
+```bash
+# Get Gemini API key: https://ai.google.dev/gemini-api/docs/api-key
+# Build server binary
+go build -o server cmd/server/*.go
+
+# Configure environment (.env file)
 API_KEYS=key1,key2,key3
-DAILY_CALL_LIMIT=100
-GEMINI_API_KEY=your_gemini_key
+DAILY_CALL_LIMIT=100  
+GEMINI_API_KEY=your_gemini_key_here
+
+# Run server
+./server
 ```
 
-### Client Setup
+## Development
 
-Configure your API key in the client environment:
-
-```bash
-# Client .env  
-API_KEY=key1
-```
-
-## Quick Start
-
-**Development (requires API key):**
-
-```bash
-git clone <repo> && cd microchat.ai
-./certs/generate-certs.sh
-cp .env.example .env
-# Edit .env to add API_KEYS for server and API_KEY for client
-make dev-server        # Terminal 1
-make dev-client-echo    # Terminal 2
-```
-
-**Production (requires API keys + Gemini API key):**
-
-1. Get Gemini API key: <https://ai.google.dev/gemini-api/docs/api-key>
-2. Generate your authentication API keys
-3. Add to server `.env`: `API_KEYS=key1,key2`, `DAILY_CALL_LIMIT=100`, and `GEMINI_API_KEY=your_key_here`
-4. Add to client `.env`: `API_KEY=key1`
-5. Run: `make prod-server` and `make prod-client-gemini`
-
-## Environment Variables
-
-Copy `.env.example` to `.env` and configure:
-
-**Server:**
-- `API_KEYS` - Comma-separated list of valid API keys (required)
-- `DAILY_CALL_LIMIT` - Daily call limit per API key (default: 100)
-- `GEMINI_API_KEY` - Your Gemini API key (production only)
-- `APP_ENV=development` - Enables Echo provider
-- Certificate paths - Use defaults for development
-
-**Client:**  
-- `API_KEY` - Your API key for server authentication (required)
-- Certificate paths - Use defaults for development
+For local development with self-signed certs, see `.env.example` for config.


### PR DESCRIPTION
## Summary
- Auto-detects production vs development servers for TLS configuration
- Uses system CA certificates for production domains (e.g., microchat.ai:443)
- Keeps self-signed certificate support for localhost/development
- Renames API_KEY to MICROCHAT_API_KEY to avoid environment variable conflicts
- Simplifies Makefile with development-focused targets and security scanning

## Test plan
- [x] TLS auto-detection works for production domains
- [x] Self-signed certificates work for localhost development
- [x] All client tests pass with proper session handling
- [x] Security scanning with govulncheck integrated
- [x] README updated with concise client setup instructions

Resolves #36