### PR TITLE
Add pprof profiling with production-ready security (#22)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ MAX_MESSAGES_PER_SESSION=100
 MAX_SESSION_SIZE_KB=100
 RATE_LIMIT_RPS=10
 RATE_LIMIT_BURST=20
+PPROF_PORT=6060
 
 # CLIENT (.env):
 MICROCHAT_API_KEY=dev-key-1
@@ -50,6 +51,7 @@ MAX_MESSAGES_PER_SESSION=100
 MAX_SESSION_SIZE_KB=100
 RATE_LIMIT_RPS=10
 RATE_LIMIT_BURST=20
+PPROF_PORT=6060
 
 # CLIENT (.env):
 MICROCHAT_API_KEY=secure-prod-key-1
@@ -87,3 +89,6 @@ CA_CERT_FILE=/etc/ssl/certs/ca.crt
 # MAX_SESSIONS - Maximum concurrent sessions (default: 1000)
 # MAX_MESSAGES_PER_SESSION - Maximum messages per session (default: 100)  
 # MAX_SESSION_SIZE_KB - Maximum memory per session in KB (default: 100)
+
+# PROFILING (for debugging performance issues)
+# PPROF_PORT - Port for pprof profiling server, localhost only (default: 6060)

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,25 @@ admin-metrics:
 		chat.ChatService/GetMetrics
 
 # =============================================================================
+# PROFILING
+# =============================================================================
+
+pprof-cpu:
+	@if [ -z "$$ADMIN_KEY" ]; then echo "Error: Set ADMIN_KEY environment variable"; exit 1; fi
+	curl -H "Authorization: Bearer $$ADMIN_KEY" -o /tmp/cpu.prof 'http://127.0.0.1:6060/debug/pprof/profile?seconds=30'
+	go tool pprof /tmp/cpu.prof
+
+pprof-heap:
+	@if [ -z "$$ADMIN_KEY" ]; then echo "Error: Set ADMIN_KEY environment variable"; exit 1; fi
+	curl -H "Authorization: Bearer $$ADMIN_KEY" -o /tmp/heap.prof http://127.0.0.1:6060/debug/pprof/heap
+	go tool pprof /tmp/heap.prof
+
+pprof-goroutines:
+	@if [ -z "$$ADMIN_KEY" ]; then echo "Error: Set ADMIN_KEY environment variable"; exit 1; fi
+	curl -H "Authorization: Bearer $$ADMIN_KEY" -o /tmp/goroutine.prof http://127.0.0.1:6060/debug/pprof/goroutine
+	go tool pprof /tmp/goroutine.prof
+
+# =============================================================================
 # TOOLS
 # =============================================================================
 
@@ -73,4 +92,5 @@ audit:
 .PHONY: server \
         client client-echo client-gemini client-gemini-metrics client-gemini-detail \
         admin-metrics \
+        pprof-cpu pprof-heap pprof-goroutines \
         proto test test-server build audit

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,89 @@
+# Profiling Guide
+
+## Overview
+
+Pprof profiling enables runtime introspection of the live server to debug performance issues.
+
+## Purpose
+
+**Benchmarks** measure system capabilities offline. **Profiling** debugs live issues during incidents.
+
+## Security
+
+**Production-Ready Security Features:**
+
+1. **Localhost Only**: Server binds to `127.0.0.1` only - not accessible from network
+2. **Admin Authentication**: Bearer token required for all endpoints 
+3. **Configurable Port**: Set `PPROF_PORT` environment variable (default: 6060)
+4. **Graceful Shutdown**: Server shuts down cleanly with main process
+5. **Isolated State**: Uses dedicated ServeMux, no global DefaultServeMux pollution
+
+**Production Access**: Use SSH tunnel to access profiling endpoints securely:
+```bash
+ssh -L 6060:127.0.0.1:6060 user@production-server
+# Then access http://127.0.0.1:6060 locally
+```
+
+## Available Endpoints
+
+Server automatically exposes profiling endpoints on `127.0.0.1:6060` (localhost only):
+
+- `/debug/pprof/` - Index page with all available profiles
+- `/debug/pprof/profile` - CPU profile (default 30 seconds)
+- `/debug/pprof/heap` - Current heap memory usage
+- `/debug/pprof/goroutine` - All goroutine stack traces
+- `/debug/pprof/block` - Goroutines blocked on synchronization
+- `/debug/pprof/mutex` - Mutex contention hotspots
+
+## Quick Commands
+
+```bash
+# Set admin key (required for all profiling commands)
+export ADMIN_KEY=your-admin-key-here
+
+# CPU profiling (30 seconds)
+make pprof-cpu
+
+# Heap memory analysis
+make pprof-heap
+
+# Goroutine inspection
+make pprof-goroutines
+
+# Custom duration CPU profile
+curl -H "Authorization: Bearer $ADMIN_KEY" -o /tmp/cpu.prof 'http://127.0.0.1:6060/debug/pprof/profile?seconds=60'
+go tool pprof /tmp/cpu.prof
+
+## Configuration
+
+Set environment variables to customize profiling:
+
+```bash
+export PPROF_PORT=6060      # Default profiling port
+export ADMIN_KEY=your-key   # Required for authentication
+```
+
+## When to Use Profiling
+
+| Problem | Profile Type | Investigation |
+|---|---|---|
+| High CPU usage | CPU profile | Which functions consume most CPU time |
+| Memory leaks | Heap profile | What objects are accumulating in memory |
+| High latency | CPU + goroutine | Blocking operations and slow functions |
+| Deadlocks | Goroutine profile | Stack traces of all goroutines |
+| Resource contention | Mutex/block profiles | Synchronization bottlenecks |
+
+## Zero Overhead
+
+Profiling has **zero runtime cost** until endpoints are accessed. The pprof HTTP server runs separately from the main gRPC server on port 6060.
+
+## Interactive Analysis
+
+After capturing a profile, pprof opens an interactive shell:
+
+```
+(pprof) top10          # Show top 10 functions by CPU time
+(pprof) list main.Chat # Show source code with timing annotations
+(pprof) web           # Generate visual graph (requires graphviz)
+(pprof) peek main.Chat # Show callers/callees of function
+```


### PR DESCRIPTION
## Summary

- **Branch 2 implementation** from issue #22 - adds pprof profiling for runtime debugging
- **Production-ready security**: Localhost-only binding, admin authentication, graceful shutdown
- **Configurable**:  environment variable (default: 6060)
- **Zero overhead** until accessed - minimal performance impact
- **Complete tooling**: Makefile commands and documentation

## Security Features

✅ **Localhost binding** () - not accessible from network  
✅ **Admin authentication** - Bearer token required for all endpoints  
✅ **Graceful shutdown** - integrated with main server lifecycle  
✅ **Isolated state** - dedicated ServeMux, no global pollution  
✅ **Optimized handlers** - single wrapper for all pprof routes  

## Usage

```bash
# Set admin key  
export ADMIN_KEY=your-admin-key

# Profile CPU, heap, or goroutines
make pprof-cpu
make pprof-heap  
make pprof-goroutines
```

## Production Access

Use SSH tunnel for secure remote access:
```bash
ssh -L 6060:127.0.0.1:6060 user@production-server
```

## Test Plan

- [x] All pprof endpoints working with authentication
- [x] Localhost-only security verified  
- [x] Configurable port functionality tested
- [x] Graceful shutdown integration tested
- [x] Documentation and .env.example updated
- [x] Makefile commands working correctly

Addresses issue #22 Branch 2 requirements with production-ready implementation.