### PR TITLE
Add secure VPS deployment with critical security fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,10 +40,10 @@ CA_CERT_FILE=certs/ca.crt
 # SERVER (.env):
 API_KEYS=secure-prod-key-1,secure-prod-key-2,admin-prod-key:admin
 DAILY_CALL_LIMIT=50
-GEMINI_API_KEY=AIzaSy_your_actual_key_here
+GEMINI_API_KEY=YOUR_GEMINI_API_KEY
 APP_ENV=production
-TLS_CERT_FILE=/etc/ssl/certs/server.crt
-TLS_KEY_FILE=/etc/ssl/private/server.key
+TLS_CERT_FILE=certs/server.crt
+TLS_KEY_FILE=certs/server.key
 PORT=4000
 SESSION_CLEANUP_INTERVAL=15m
 SESSION_IDLE_TIMEOUT=2h

--- a/certs/generate-certs.sh
+++ b/certs/generate-certs.sh
@@ -1,30 +1,33 @@
 #!/bin/bash
 set -e
-# Generate development certificates for microchat.ai
+# Generate ECDSA P-384 certificates for microchat.ai
 
-echo "Generating development certificates..."
+echo "Generating ECDSA P-384 certificates..."
 
 # Get script directory to ensure files are created in certs/
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-# Generate CA private key
-openssl genrsa -out ca.key 4096
+# Generate CA private key with ECDSA P-384
+openssl ecparam -name secp384r1 -genkey -out ca.key
 
 # Generate CA certificate
-openssl req -new -x509 -days 365 -key ca.key -out ca.crt -subj "/CN=MicroChat CA"
+openssl req -new -x509 -days 90 -key ca.key -out ca.crt -subj "/CN=MicroChat CA" -sha384
 
-# Generate server private key
-openssl genrsa -out server.key 4096
+# Generate server private key with ECDSA P-384
+openssl ecparam -name secp384r1 -genkey -out server.key
 
 # Generate server certificate signing request with Subject Alternative Names
-openssl req -new -key server.key -out server.csr -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+openssl req -new -key server.key -out server.csr -subj "/CN=localhost" \
+    -addext "subjectAltName=DNS:localhost,DNS:microchat.ai,IP:127.0.0.1"
 
-# Sign server certificate with CA
-openssl x509 -req -days 365 -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -copy_extensions copy
+# Sign server certificate with CA using SHA-384
+openssl x509 -req -days 90 -in server.csr -CA ca.crt -CAkey ca.key \
+    -CAcreateserial -out server.crt -sha384 -copy_extensions copy
 
 # Clean up temporary files
 rm server.csr ca.srl
 
-echo "Development certificates generated successfully!"
+echo "ECDSA P-384 certificates generated successfully!"
 echo "Files created in certs/: ca.crt, ca.key, server.crt, server.key"
+echo "Certificate validity: 90 days (renewal recommended at 60 days)"

--- a/deploy/ADVANCED_HARDENING.md
+++ b/deploy/ADVANCED_HARDENING.md
@@ -1,0 +1,102 @@
+# Advanced Security Hardening
+
+Optional security configurations for production deployments.
+
+## Current Security Features
+
+Default `microchat.service` includes:
+
+- Dedicated service user (`microchat`)
+- Filesystem isolation (`ProtectSystem=full`, `ProtectHome=true`)
+- Device isolation (`PrivateDevices=true`)
+- Capability restrictions (`CapabilityBoundingSet=CAP_NET_BIND_SERVICE`)
+- System call filtering (`SystemCallFilter=@system-service`)
+
+## Network Isolation Options
+
+### Option 1: Complete Isolation + Proxy
+
+Block all outbound connections, use proxy:
+
+```ini
+# In microchat.service [Service] section
+IPAddressDeny=any
+IPAddressAllow=localhost
+Environment=HTTPS_PROXY=http://127.0.0.1:3128
+```
+
+Setup proxy:
+
+```bash
+sudo apt install squid
+# Edit /etc/squid/squid.conf:
+# acl apis dstdomain .googleapis.com .openai.com .anthropic.com
+# http_access allow apis
+# http_access deny all
+```
+
+### Option 2: DNS Whitelisting
+
+Dynamic IP resolution:
+
+```bash
+# Script to resolve and allow API domains
+for domain in generativelanguage.googleapis.com; do
+    systemctl set-property microchat.service IPAddressAllow="$(dig +short $domain)/32"
+done
+```
+
+### Option 3: Firewall
+
+Use iptables:
+
+```bash
+sudo iptables -I OUTPUT -m owner --uid-owner microchat -j DROP
+sudo iptables -I OUTPUT -m owner --uid-owner microchat \
+    -d $(dig +short generativelanguage.googleapis.com) -j ACCEPT
+```
+
+## Additional Hardening
+
+### Memory Protection
+
+```ini
+MemoryDenyWriteExecute=true
+RestrictRealtime=true
+LockPersonality=true
+```
+
+### Filesystem
+
+```ini
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ReadWritePaths=/opt/microchat/logs
+```
+
+### Resource Limits
+
+```ini
+CPUQuota=50%
+MemoryMax=512M
+TasksMax=100
+```
+
+## Testing
+
+### Verify Isolation
+
+```bash
+# Should fail
+sudo -u microchat ls /root
+
+# Should work  
+sudo -u microchat nc -l 4000
+```
+
+### Check Capabilities
+
+```bash
+sudo -u microchat capsh --print
+```
+

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,61 @@
+microchat.ai {
+	# Enable compression (gzip, zstd, brotli)
+	encode gzip zstd br
+	
+	# Rate limiting matching .env.example (10 RPS, burst 20)
+	rate_limit {
+		zone dynamic {
+			key {remote_host}
+			events 10
+			window 1s
+			burst 20
+		}
+	}
+	
+	# Security headers
+	header {
+		X-Frame-Options "DENY"
+		X-Content-Type-Options "nosniff"
+		X-XSS-Protection "1; mode=block"
+		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+		Content-Security-Policy "default-src 'none'; frame-ancestors 'none'"
+		Referrer-Policy "no-referrer"
+		Permissions-Policy "geolocation=(), microphone=(), camera=()"
+		-Server
+	}
+	
+	# Request size limit (1MB for compressed gRPC)
+	request_body {
+		max_size 1MB
+	}
+	
+	@grpc {
+		header Content-Type application/grpc*
+	}
+
+	handle @grpc {
+		reverse_proxy https://localhost:4000 {
+			transport http {
+				tls_trusted_ca_certs /opt/microchat/certs/ca.crt
+				versions 1.2 1.3
+			}
+			# Health check
+			health_uri /chat.ChatService/Health
+			health_interval 30s
+			health_timeout 5s
+		}
+	}
+
+	handle {
+		respond "Not Found" 404
+	}
+	
+	# Access logging for security monitoring
+	log {
+		output file /var/log/caddy/access.log {
+			roll_size 100mb
+			roll_keep 10
+		}
+		format json
+	}
+}

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# deployment script for microchat.ai - run as microchat user
+set -e
+
+# Check if running as microchat user
+if [ "$(whoami)" != "microchat" ]; then
+    echo "Error: This script must be run as the microchat user"
+    echo "Usage: sudo -u microchat ./deploy/deploy.sh"
+    exit 1
+fi
+
+echo "building & deploying microchat.ai..."
+
+# Update code (fast-forward only, prevents merge conflicts)
+git pull --ff-only origin main
+
+# Build server (no sudo needed - user owns the directory)
+go build -o server cmd/server/*.go
+
+# Restart systemd service if it exists
+# Requires sudoers entry: microchat ALL=(ALL) NOPASSWD: /bin/systemctl restart microchat
+if systemctl is-enabled microchat &>/dev/null; then
+  sudo systemctl restart microchat
+  echo "service restarted"
+else
+  echo "failed to start microchat.service. please check: /etc/systemd/system/"
+fi
+
+echo "build & deployment complete!"
+

--- a/deploy/microchat.service
+++ b/deploy/microchat.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=microchat.ai server
+After=network.target
+
+[Service]
+Type=simple
+User=microchat
+WorkingDirectory=/opt/microchat
+ExecStart=/opt/microchat/server
+Restart=always
+RestartSec=10
+EnvironmentFile=/opt/microchat/.env
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+PrivateDevices=true
+
+# Capability restrictions - drop all except network bind
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# System call filtering
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+
+# Memory protection - prevents code injection exploits
+MemoryDenyWriteExecute=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Deploy script now runs as microchat user (eliminates root privileges)
- Upgrade TLS to ECDSA P-384 certificates with 90-day validity  
- Harden Caddy with rate limiting (10 RPS/burst 20), compression, security headers
- Add comprehensive deployment documentation and sudoers configuration
- Implement privilege separation and service isolation

## Test plan
- [x] Test deployment script runs correctly as microchat user
- [x] Verify ECDSA certificates generate properly
- [x] Confirm Caddy configuration loads without errors
- [x] Test rate limiting and security headers are applied
- [x] Validate systemd service starts and restarts correctly