### PR TITLE
Fix Caddy reverse proxy gRPC port configuration

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -24,7 +24,7 @@ microchat.ai {
 	}
 
 	handle @grpc {
-		reverse_proxy https://localhost:4002 {
+		reverse_proxy https://localhost:4000 {
 			transport http {
 				tls_trusted_ca_certs /opt/microchat/certs/ca.crt
 			}


### PR DESCRIPTION
Update the gRPC reverse proxy port from 4002 to 4000 in the Caddy configuration to match the correct service port.